### PR TITLE
Rename Go module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```
-go get github.com/annexhq/annex-sdk-go
+go get github.com/annexsh/annex-sdk-go
 ```
 
 ## Disclaimer

--- a/definition.go
+++ b/definition.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"reflect"
 
-	testv1 "github.com/annexhq/annex-proto/gen/go/type/test/v1"
+	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/workflow"
 
-	"github.com/annexhq/annex-sdk-go/internal/name"
-	"github.com/annexhq/annex-sdk-go/internal/test"
-	"github.com/annexhq/annex-sdk-go/internal/testing"
+	"github.com/annexsh/annex-sdk-go/internal/name"
+	"github.com/annexsh/annex-sdk-go/internal/test"
+	"github.com/annexsh/annex-sdk-go/internal/testing"
 )
 
 type simpleTest struct {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/annexhq/annex-sdk-go
+module github.com/annexsh/annex-sdk-go
 
 go 1.22.0
 
 require (
-	github.com/annexhq/annex v0.0.0-20240530212531-fe027cbf10b2
-	github.com/annexhq/annex-proto v0.0.0-20240603062920-3b6f92e0f992
+	github.com/annexsh/annex v0.0.0-20240604141651-20f0440a3a87
+	github.com/annexsh/annex-proto v0.0.0-20240604135603-ff6a86059f03
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/annexhq/annex v0.0.0-20240530212531-fe027cbf10b2 h1:67mGpMJK01fqQC7f/WPWxH7+DY75T0FDBnvPILt43/c=
-github.com/annexhq/annex v0.0.0-20240530212531-fe027cbf10b2/go.mod h1:SZ7ihQLIMhQWVNnUHus2X9k5wr1TQoSIj2y+DzCmq4Y=
-github.com/annexhq/annex-proto v0.0.0-20240603062920-3b6f92e0f992 h1:xJ7liPSDhy4e7vCoG+4+ckWgRfij/I+w3MFNtzVYIUY=
-github.com/annexhq/annex-proto v0.0.0-20240603062920-3b6f92e0f992/go.mod h1:DSGBmFfVcqUeh9rVjHeZq9bFyZkSQ5MPdTFZ8X58X9E=
+github.com/annexsh/annex v0.0.0-20240604141651-20f0440a3a87 h1:zmd8c0ERAeXQmu9Ov5dAgTbTI/ccswbMRfbv5dl7nOc=
+github.com/annexsh/annex v0.0.0-20240604141651-20f0440a3a87/go.mod h1:20zXGObA90mQDDX1DXEMb98DjZvFlJTXL2pn/SQbVO4=
+github.com/annexsh/annex-proto v0.0.0-20240604135603-ff6a86059f03 h1:oFYUf37JbjXBUX8QmaKpzGqFpkjRGkxiGjrl23pL4oA=
+github.com/annexsh/annex-proto v0.0.0-20240604135603-ff6a86059f03/go.mod h1:yxmzF5yk/8rLEKu5VRbsMo1jFHB4/RotPSFrzMSJW2U=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=

--- a/internal/temporal/log_context.go
+++ b/internal/temporal/log_context.go
@@ -3,7 +3,7 @@ package temporal
 import (
 	"context"
 
-	"github.com/annexhq/annex/test"
+	"github.com/annexsh/annex/test"
 	"go.temporal.io/sdk/workflow"
 )
 

--- a/internal/temporal/logger.go
+++ b/internal/temporal/logger.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	testservicev1 "github.com/annexhq/annex-proto/gen/go/rpc/testservice/v1"
-	"github.com/annexhq/annex/test"
+	testservicev1 "github.com/annexsh/annex-proto/gen/go/rpc/testservice/v1"
+	"github.com/annexsh/annex/test"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/activity"
 	tlog "go.temporal.io/sdk/log"

--- a/internal/test/case.go
+++ b/internal/test/case.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/annexhq/annex/test"
+	"github.com/annexsh/annex/test"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/activity"
 
-	"github.com/annexhq/annex-sdk-go/internal/temporal"
+	"github.com/annexsh/annex-sdk-go/internal/temporal"
 )
 
 type resultKey struct{}

--- a/internal/test/decode.go
+++ b/internal/test/decode.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	testv1 "github.com/annexhq/annex-proto/gen/go/type/test/v1"
+	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
 )

--- a/internal/test/execute.go
+++ b/internal/test/execute.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 
-	testv1 "github.com/annexhq/annex-proto/gen/go/type/test/v1"
-	"github.com/annexhq/annex/test"
+	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
+	"github.com/annexsh/annex/test"
 	"go.temporal.io/sdk/workflow"
 
-	"github.com/annexhq/annex-sdk-go/internal/temporal"
+	"github.com/annexsh/annex-sdk-go/internal/temporal"
 )
 
 type TestExecutor func(ctx workflow.Context, payload *testv1.Payload) error

--- a/internal/test/pending.go
+++ b/internal/test/pending.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/annexhq/annex/test"
+	"github.com/annexsh/annex/test"
 	"go.temporal.io/sdk/workflow"
 )
 

--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/annexhq/annex/test"
+	"github.com/annexsh/annex/test"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"

--- a/runner.go
+++ b/runner.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"reflect"
 
-	testservicev1 "github.com/annexhq/annex-proto/gen/go/rpc/testservice/v1"
-	testv1 "github.com/annexhq/annex-proto/gen/go/type/test/v1"
+	testservicev1 "github.com/annexsh/annex-proto/gen/go/rpc/testservice/v1"
+	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
 	"github.com/denisbrodbeck/machineid"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/annexhq/annex-sdk-go/internal/temporal"
+	"github.com/annexsh/annex-sdk-go/internal/temporal"
 )
 
 const taskQueue = "default" // TODO: configurable

--- a/test.go
+++ b/test.go
@@ -10,8 +10,8 @@ import (
 	temporalsdk "go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
-	"github.com/annexhq/annex-sdk-go/internal/name"
-	"github.com/annexhq/annex-sdk-go/internal/test"
+	"github.com/annexsh/annex-sdk-go/internal/name"
+	"github.com/annexsh/annex-sdk-go/internal/test"
 )
 
 type CaseFunc func(ctx context.Context)

--- a/testing.go
+++ b/testing.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/annexhq/annex-sdk-go/internal/test"
-	"github.com/annexhq/annex-sdk-go/internal/testing"
+	"github.com/annexsh/annex-sdk-go/internal/test"
+	"github.com/annexsh/annex-sdk-go/internal/testing"
 )
 
 type TestT interface {


### PR DESCRIPTION
GitHub organisation has been renamed to `annexsh`. This PR updates the repository Go module name to use the new address.