### PR TITLE
Migrate to Connect RPC

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
-	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
+	"github.com/annexsh/annex-proto/gen/go/annex/tests/v1"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/workflow"
 
@@ -19,7 +19,7 @@ type simpleTest struct {
 	test func(t TestT)
 }
 
-func (f *simpleTest) workflow(ctx workflow.Context, payload *testv1.Payload) error {
+func (f *simpleTest) workflow(ctx workflow.Context, payload *testsv1.Payload) error {
 	if f.test == nil {
 		return errors.New("flow cannot be nil")
 	}
@@ -41,7 +41,7 @@ type paramTest[P any] struct {
 	test func(t TestT, param P)
 }
 
-func (f *paramTest[P]) workflow(ctx workflow.Context, payload *testv1.Payload) error {
+func (f *paramTest[P]) workflow(ctx workflow.Context, payload *testsv1.Payload) error {
 	if f.test == nil {
 		return errors.New("test cannot be nil")
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/annexsh/annex-sdk-go
 go 1.22.0
 
 require (
-	github.com/annexsh/annex v0.0.0-20240611234527-4a16dcb728b9
-	github.com/annexsh/annex-proto v0.0.0-20240611232825-bec6cd17612d
+	connectrpc.com/connect v1.16.2
+	github.com/annexsh/annex v0.0.0-20240623025614-cd7f1964e3b6
+	github.com/annexsh/annex-proto v0.0.0-20240623024904-02c7160f793e
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+connectrpc.com/connect v1.16.2 h1:ybd6y+ls7GOlb7Bh5C8+ghA6SvCBajHwxssO2CGFjqE=
+connectrpc.com/connect v1.16.2/go.mod h1:n2kgwskMHXC+lVqb18wngEpF95ldBHXjZYJussz5FRc=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/annexsh/annex v0.0.0-20240611234527-4a16dcb728b9 h1:Hw4EGHAQKKHKDMqVeMYlVg+JrViQyCVi6tmPHlSEQ1I=
-github.com/annexsh/annex v0.0.0-20240611234527-4a16dcb728b9/go.mod h1:zZF1KKS4eefjGIsmZfngdss3F1o5Nagb3uRgZpH3VPw=
-github.com/annexsh/annex-proto v0.0.0-20240611232825-bec6cd17612d h1:eBQtC7dPPRoOPM9IXW/572D5DWwGQa8wXHNl/ee9IOw=
-github.com/annexsh/annex-proto v0.0.0-20240611232825-bec6cd17612d/go.mod h1:yxmzF5yk/8rLEKu5VRbsMo1jFHB4/RotPSFrzMSJW2U=
+github.com/annexsh/annex v0.0.0-20240623025614-cd7f1964e3b6 h1:DF/xPYl8rAQYUpLJaO5NoLxx7hzrHpX5BaR+T/lTNxc=
+github.com/annexsh/annex v0.0.0-20240623025614-cd7f1964e3b6/go.mod h1:SqGveC8bb0EZtPhmnEm71mX954H9DjNHk0ft92wUrOY=
+github.com/annexsh/annex-proto v0.0.0-20240623024904-02c7160f793e h1:JsPQmNrf1nJGBXb8IbCrz+08x/biS2oKrjQcndeUF9k=
+github.com/annexsh/annex-proto v0.0.0-20240623024904-02c7160f793e/go.mod h1:pzaEDW9K5m9D4MHE1RGlgBVcE525eaEdzNEGb0SMClc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=

--- a/internal/temporal/client.go
+++ b/internal/temporal/client.go
@@ -9,6 +9,8 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func NewClient(ctx context.Context, hostPort string, namespace string) (client.Client, error) {
@@ -16,7 +18,10 @@ func NewClient(ctx context.Context, hostPort string, namespace string) (client.C
 		HostPort:      hostPort,
 		Namespace:     namespace,
 		DataConverter: converter.GetDefaultDataConverter(),
-		Logger:        NewLogger(),
+		ConnectionOptions: client.ConnectionOptions{
+			DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		},
+		Logger: NewLogger(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/temporal/logger.go
+++ b/internal/temporal/logger.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"time"
 
-	testservicev1 "github.com/annexsh/annex-proto/gen/go/rpc/testservice/v1"
+	"connectrpc.com/connect"
+	"github.com/annexsh/annex-proto/gen/go/annex/tests/v1"
 	"github.com/annexsh/annex/test"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/activity"
 	tlog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -81,7 +81,10 @@ func (l *Logger) log(level Level, msg string, keyvals ...any) {
 var _ tlog.Logger = (*TestActivityLogger)(nil)
 
 type LogPublisher interface {
-	PublishTestExecutionLog(ctx context.Context, in *testservicev1.PublishTestExecutionLogRequest, opts ...grpc.CallOption) (*testservicev1.PublishTestExecutionLogResponse, error)
+	PublishTestExecutionLog(
+		ctx context.Context,
+		req *connect.Request[testsv1.PublishTestExecutionLogRequest],
+	) (*connect.Response[testsv1.PublishTestExecutionLogResponse], error)
 }
 
 type CaseOption func(logger *TestActivityLogger)
@@ -130,7 +133,7 @@ func (l *TestActivityLogger) Error(msg string, keyvals ...any) {
 
 func (l *TestActivityLogger) log(level Level, msg string, keyvals []any) {
 	if !l.testExecID.IsEmpty() {
-		req := &testservicev1.PublishTestExecutionLogRequest{
+		req := &testsv1.PublishTestExecutionLogRequest{
 			TestExecutionId: l.testExecID.String(),
 			CaseExecutionId: nil,
 			Level:           string(level),
@@ -145,7 +148,7 @@ func (l *TestActivityLogger) log(level Level, msg string, keyvals []any) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), logRequestTimeout)
 		defer cancel()
-		if _, err := l.pub.PublishTestExecutionLog(ctx, req); err != nil {
+		if _, err := l.pub.PublishTestExecutionLog(ctx, connect.NewRequest(req)); err != nil {
 			kv := append(keyvals, "error", err)
 			l.Logger.Error("failed to publish log", kv...)
 		}
@@ -186,20 +189,20 @@ func (t *TestLogActivity) Publish(ctx context.Context, req TestLogRequest) (*Tes
 
 	keyVals := req.GlobalKeyVals + strings.TrimSuffix(fmt.Sprintln(req.KeyVals...), "\n")
 
-	pubReq := &testservicev1.PublishTestExecutionLogRequest{
+	pubReq := &testsv1.PublishTestExecutionLogRequest{
 		TestExecutionId: req.TestExecutionID.String(),
 		Level:           string(req.Level),
 		Message:         req.Message + " " + keyVals,
-		CreateTime:      timestamppb.Now(),
+		CreateTime:      timestamppb.New(time.Now().UTC()),
 	}
 
-	res, err := t.pub.PublishTestExecutionLog(ctx, pubReq)
+	res, err := t.pub.PublishTestExecutionLog(ctx, connect.NewRequest(pubReq))
 	if err != nil {
 		kv := append(req.KeyVals, "error", err)
 		logger.Error("failed to publish test log", kv...)
 	}
 
-	logID, err := uuid.Parse(res.LogId)
+	logID, err := uuid.Parse(res.Msg.LogId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/test/decode.go
+++ b/internal/test/decode.go
@@ -1,12 +1,12 @@
 package test
 
 import (
-	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
+	"github.com/annexsh/annex-proto/gen/go/annex/tests/v1"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
 )
 
-func DecodeParam[P any](payload *testv1.Payload) (P, error) {
+func DecodeParam[P any](payload *testsv1.Payload) (P, error) {
 	converted := convertAnnexPayload(payload)
 	dc := converter.GetDefaultDataConverter()
 	var param P
@@ -25,7 +25,7 @@ func DecodeTemporalParam[P any](payload *common.Payload) (P, error) {
 	return param, nil
 }
 
-func convertAnnexPayload(testPayload *testv1.Payload) *common.Payload {
+func convertAnnexPayload(testPayload *testsv1.Payload) *common.Payload {
 	return &common.Payload{
 		Metadata: testPayload.Metadata,
 		Data:     testPayload.Data,

--- a/internal/test/execute.go
+++ b/internal/test/execute.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"fmt"
 
-	testv1 "github.com/annexsh/annex-proto/gen/go/type/test/v1"
+	"github.com/annexsh/annex-proto/gen/go/annex/tests/v1"
 	"github.com/annexsh/annex/test"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/annexsh/annex-sdk-go/internal/temporal"
 )
 
-type TestExecutor func(ctx workflow.Context, payload *testv1.Payload) error
+type TestExecutor func(ctx workflow.Context, payload *testsv1.Payload) error
 
 func ExecuteTest(ctx workflow.Context, wf func(ctx workflow.Context)) error {
 	weInfo := workflow.GetInfo(ctx)


### PR DESCRIPTION
### Description

Migrate Annex APIs to Connect RPC. 

A detailed outline of the decision can be found in https://github.com/annexsh/annex-proto/pull/10.